### PR TITLE
Dashboard Preview: Hard-code modern blue for the charts

### DIFF
--- a/src/examples/DashboardPreview.tsx
+++ b/src/examples/DashboardPreview.tsx
@@ -33,7 +33,7 @@ const barChartData = {
   datasets: [
     {
       data: [65, 59, 80, 81, 56, 55],
-      backgroundColor: "#0073aa",
+      backgroundColor: "#3858e9",
     },
   ],
 };
@@ -43,7 +43,7 @@ const lineChartData = {
   datasets: [
     {
       data: [12, 19, 3, 5, 2, 3, 9],
-      borderColor: "#0073aa",
+      borderColor: "#3858e9",
       fill: false,
     },
   ],


### PR DESCRIPTION
Related to #2:

This isn't a _proper_ fix, but updates the DashboardPreview component to use a hard-coded color that matches the Modern theme. I'm very happy for us to close this PR if isn't desired! It'll look okay with the Modern theme, but likely look odd when choosing any other color scheme:

### Before

Note that the colors in the charts do not match the theme selected (Modern)

<img width="1257" alt="image" src="https://github.com/user-attachments/assets/b23b36b2-45bc-4cc6-97c9-7bb6a8790c0b" />

### After

Note that the colors in the charts now match Modern, but do not update to reflect the chosen theme. More discussion over in #2 

| With Modern selected | With another selected |
| --- | --- |
| <img width="1259" alt="image" src="https://github.com/user-attachments/assets/c17d633e-1668-444e-a76c-f6a109aaf564" /> | <img width="1262" alt="image" src="https://github.com/user-attachments/assets/1570d3a4-6e93-45af-8f91-30809529a157" /> |